### PR TITLE
Add frontend for search

### DIFF
--- a/graphite-demo/frontend.jsx
+++ b/graphite-demo/frontend.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
-const TaskAndUserSearch = () => {
+const TaskSearch = () => {
   const [tasks, setTasks] = useState([]);
-  const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -17,15 +16,14 @@ const TaskAndUserSearch = () => {
         return response.json();
       })
       .then(data => {
-        setTasks(data.tasks);
-        setUsers(data.users);
+        setTasks(data);
         setLoading(false);
       })
       .catch(error => {
         setError(error.message);
         setLoading(false);
       });
-  }, [searchQuery]);
+  }, [searchQuery]); // Depend on searchQuery
 
   if (loading) {
     return <div>Loading...</div>;
@@ -37,14 +35,13 @@ const TaskAndUserSearch = () => {
 
   return (
     <div>
-      <h2>Search Tasks and Users</h2>
+      <h2>Task Search</h2>
       <input
         type="text"
-        placeholder="Search tasks and users..."
+        placeholder="Search tasks..."
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />
-      <h3>Tasks</h3>
       <ul>
         {tasks.map(task => (
           <li key={task.id}>
@@ -52,16 +49,8 @@ const TaskAndUserSearch = () => {
           </li>
         ))}
       </ul>
-      <h3>Users</h3>
-      <ul>
-        {users.map(user => (
-          <li key={user.id}>
-            <p>{user.name}</p>
-          </li>
-        ))}
-      </ul>
     </div>
   );
 };
 
-export default TaskAndUserSearch;
+export default TaskSearch;


### PR DESCRIPTION
### TL;DR

Simplified the component to focus only on task search functionality, removing user search capabilities.

### What changed?

- Renamed component from `TaskAndUserSearch` to `TaskSearch`
- Removed the `users` state and related UI elements
- Updated the API response handling to expect only task data
- Updated component title and search placeholder text
- Added a comment clarifying the dependency on `searchQuery` in the useEffect hook
- Updated the default export to match the new component name

### How to test?

1. Verify the component renders correctly with only task search functionality
2. Confirm the search input works and filters tasks properly
3. Check that the API response is correctly processed as a direct task array
4. Ensure no errors appear in the console related to missing user data

### Why make this change?

This change streamlines the component to have a single responsibility - searching tasks. By removing the user search functionality, the component becomes more focused and easier to maintain. This follows the single responsibility principle and makes the component more reusable in contexts where only task searching is needed.